### PR TITLE
Update links in index.html to connect to Oahu system pages

### DIFF
--- a/008/index.html
+++ b/008/index.html
@@ -146,7 +146,7 @@
 <div>
 <p class="text-text-light dark:text-text-dark text-lg font-bold leading-normal">Oahu: コア</p>
 <p class="text-slate-500 dark:text-slate-400 text-sm font-normal leading-normal">Oahuシステムの基盤となる、堅牢でスケーラブルなプラットフォーム。</p>
-<a class="text-primary font-bold text-sm mt-2 inline-block" href="#">詳しく見る →</a>
+<a class="text-primary font-bold text-sm mt-2 inline-block" href="oahu.html">詳しく見る →</a>
 </div>
 </div>
 <div class="flex flex-col gap-3 pb-3">
@@ -154,7 +154,7 @@
 <div>
 <p class="text-text-light dark:text-text-dark text-lg font-bold leading-normal">Vegas: データインサイト</p>
 <p class="text-slate-500 dark:text-slate-400 text-sm font-normal leading-normal">強力な分析とAI主導のインサイトを活用し、情報に基づいたビジネス上の意思決定を行います。</p>
-<a class="text-primary font-bold text-sm mt-2 inline-block" href="#">詳しく見る →</a>
+<a class="text-primary font-bold text-sm mt-2 inline-block" href="vegas.html">詳しく見る →</a>
 </div>
 </div>
 <div class="flex flex-col gap-3 pb-3">
@@ -162,7 +162,7 @@
 <div>
 <p class="text-text-light dark:text-text-dark text-lg font-bold leading-normal">Castro: 顧客エンゲージメント</p>
 <p class="text-slate-500 dark:text-slate-400 text-sm font-normal leading-normal">パーソナライズされたコミュニケーションとエンゲージメントツールを通じて、顧客と有意義な関係を築きます。</p>
-<a class="text-primary font-bold text-sm mt-2 inline-block" href="#">詳しく見る →</a>
+<a class="text-primary font-bold text-sm mt-2 inline-block" href="castro.html">詳しく見る →</a>
 </div>
 </div>
 <div class="flex flex-col gap-3 pb-3">
@@ -170,7 +170,7 @@
 <div>
 <p class="text-text-light dark:text-text-dark text-lg font-bold leading-normal">San Francisco: 開発者プラットフォーム</p>
 <p class="text-slate-500 dark:text-slate-400 text-sm font-normal leading-normal">柔軟で包括的なプラットフォームで、開発者がアプリケーションを構築・展開できるようにします。</p>
-<a class="text-primary font-bold text-sm mt-2 inline-block" href="#">詳しく見る →</a>
+<a class="text-primary font-bold text-sm mt-2 inline-block" href="sf.html">詳しく見る →</a>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Fixes #1

## Summary
- Updated all 4 "詳しく見る →" links in `008/index.html` to point to the corresponding Oahu system pages
- Oahu link now points to oahu.html
- Vegas link now points to vegas.html
- Castro link now points to castro.html
- San Francisco link now points to sf.html

Visitors can now navigate from the main page to individual system component pages.

🤖 Generated with [Claude Code](https://claude.ai/code)